### PR TITLE
Upgrade did_you_mean version to the latest

### DIFF
--- a/irbtools-more.gemspec
+++ b/irbtools-more.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'bond',     '~> 0.5'
   s.add_dependency 'looksee' , '~> 2.1'
   s.add_dependency 'binding_of_caller', '~> 0.7'
-  s.add_dependency 'did_you_mean', '~> 0.8'
+  s.add_dependency 'did_you_mean', '~> 0.9'
 end
 


### PR DESCRIPTION
I've just released a new version of did_you_mean. This is because 0.8.0 and older versions have a very serious bug where it changes some behaviours of Ruby 2.1.3 and 2.1.4 installed on Mac OS X. The issue has been fixed on 0.9.0  and everyone should upgrade to the latest.
